### PR TITLE
graphs and response as md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+pruebas.ipynb

--- a/ItzanaAgents.py
+++ b/ItzanaAgents.py
@@ -17,16 +17,20 @@ from typing_extensions import TypedDict
 class AnalysisOutput(TypedDict):
     """
     Esquema de salida estricto:
+    - title: titulo de la respuesta. 
     - returned_json: lista de objetos con los resultados de la consulta
     - key_findings: resumen de los hallazgos principales
     - methodology: descripción del proceso y filtros aplicados
     - results_interpretation: interpretación de lo que significan los datos
+    - recommendations: acciones recomendadas de acuerdo con la pregunta y los datos extraidos.
     - conclusion: conclusiones y próximos pasos
     """
+    title: str
     returned_json: List[Dict[str, Any]]
     key_findings: str
     methodology: str
     results_interpretation: str
+    recommendations: str
     conclusion: str
 
 @function_tool
@@ -60,24 +64,29 @@ Tu tarea es, a partir de la pregunta del usuario, **generar una consulta SQL (SQ
 
 Una vez generada la consulta, úsala llamando a la herramienta `execute_query_to_sqlite` para obtener los datos en formato JSON. **Luego, debes entregar tu respuesta en un JSON con los siguientes campos**:
 
+- `title`: un nombre para la respuesta. 
 - `returned_json`: el resultado devuelto por la consulta (en JSON).
 - `methodology`: descripción del proceso, filtros o agregaciones aplicados sin mencionar nombres de columna. 
 - `results_interpretation`: interpretación de lo que significan los datos en el contexto de negocio. Debe ser extenso. 
 - `key_findings`: resumen de los hallazgos principales extraídos de `returned_json`.
+- `recommendations`: genera recomendaciones 
 - `conclusion`: conclusiones y próximos pasos sugeridos.
 
 Devuelve **solo** un objeto JSON válido con este esquema:
 
 {{
+  "title": "..."
   "returned_json": [...],
   "key_findings": "...",
   "methodology": "...",
   "results_interpretation": "...",
+  "recommendations": "..."
   "conclusion": "..."
 }}
 
 NOTAS:
 - Si la pregunta menciona wholesalers, debes usar el campo COMPANY_NAME.
+- No uses nunca los nombres de las columnas como respuestas, debes adaptar este nombre a un lenguaje conversacional. 
 
 """
 

--- a/helper.py
+++ b/helper.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional
 
 def _generate_graphs_impl(
     data: List[Dict[str, Any]],
@@ -111,4 +111,53 @@ def _graph_all_in_one_impl(returned_json: str, userQuery: str) -> Dict[str, Any]
         "imgb64":        img
     }
 
+def format_as_markdown(
+    title: str,
+    resp: Dict[str, Any],
+    key_findings: str,
+    methodology: str,
+    interpretation: str,
+    recommendations: str,
+    conclusion: str,
+    imgb64: Optional[str] = None
+) -> str:
+    # 0) Título principal
+    md = f"# {title}\n\n"
+
+    # 1) Tabla dinámica para returned_json
+    rows = resp.get("returned_json", [])
+    if rows and isinstance(rows, list):
+        headers = list(rows[0].keys())
+        md += "## Datos\n\n"
+        md += "|" + "|".join(headers) + "|\n"
+        md += "|" + "|".join("---" for _ in headers) + "|\n"
+        for row in rows:
+            cells = ["" if row.get(h) is None else str(row[h]) for h in headers]
+            md += "|" + "|".join(cells) + "|\n"
+        md += "\n"
+    else:
+        md += "_No hay datos en returned_json_\n\n"
+
+    # 2) Secciones de texto
+    md += "## Hallazgos clave\n\n"
+    md += key_findings + "\n\n"
+
+    md += "## Metodología\n\n"
+    md += methodology + "\n\n"
+
+    md += "## Interpretación de resultados\n\n"
+    md += interpretation + "\n\n"
+
+    md += "## Recomendaciones\n\n"
+    md += recommendations + "\n\n"
+
+    md += "## Conclusión\n\n"
+    md += conclusion + "\n\n"
+
+    # 3) Imagen embebida (si existe)
+    if imgb64:
+        md += "## Gráfica\n\n"
+        md += f"![Gráfico](data:image/png;base64,{imgb64})\n"
+
+    return md
 


### PR DESCRIPTION
Changes:

- The user can now request graphs for the information generated in the table. If a key word is detected, the graph agent will try to generate an image. 
- The response of the `/ask` endpoint now returns a json containing a markdown as string, with the embedded graph image if needed. 